### PR TITLE
Update HW04 makefile to use correct output#.txt files

### DIFF
--- a/HW04/Makefile
+++ b/HW04/Makefile
@@ -12,12 +12,12 @@ SRCS = datapoint.c centroid.c hw04.c
 OBJS = $(SRCS:%.c=%.o)
 
 hw04: $(OBJS)
-	$(GCC) $(TESTFALGS) $(OBJS) -o hw04
+	$(GCC) $(TESTFALGS) $(OBJS) -o hw04 -lm
 
 .c.o:
 	$(GCC) $(TESTFALGS) -c $*.c
 
-testall: test1 test2 test3 test4 test5
+testall: test1 test2 test3 test4 test5 test6 test7 test8
 
 testadd: hw04 # hw04 here to ensure recompilation if necessary
 	test1
@@ -48,15 +48,15 @@ test5: hw04
 
 test6: hw04
 	./hw04 test/test6.txt 2 output6.txt
-	diff -i -w output5.txt expected/expected6.txt
+	diff -i -w output6.txt expected/expected6.txt
 
 test7: hw04
 	./hw04 test/test7.txt 2 output7.txt
-	diff -i -w output5.txt expected/expected7.txt
+	diff -i -w output7.txt expected/expected7.txt
 
 test8: hw04
 	./hw04 test/test8.txt 2 output8.txt
-	diff -i -w output5.txt expected/expected8.txt
+	diff -i -w output8.txt expected/expected8.txt
 
 clean: # remove all machine generated files
 	rm -f hw04 *.o 

--- a/HW04/Makefile
+++ b/HW04/Makefile
@@ -25,6 +25,9 @@ testadd: hw04 # hw04 here to ensure recompilation if necessary
 	test3
 	test4
 	test5
+	test6
+	test7
+	test8
 
 
 test1: hw04


### PR DESCRIPTION
As referenced by #4:
* in the makefile of hw04, the new test cases 6 through 8 diff with output5.txt
  * fix: change output*n*.txt to use the correct testcase output
  * also, add the extra test cases to testall if necessary
* fix undefined reference to pow
  * info [here (stackoverflow)](https://stackoverflow.com/a/16344504), but I couldn't compile without the -lm flag. This might be unnecessary for most people, and can be removed if the TAs decide. 
